### PR TITLE
Create package.json and npm run scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "vscode-settings",
+  "version": "1.0.0",
+  "description": "Jed Northridge's Visual Code Settings",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jedcn/vscode-settings.git"
+  },
+  "keywords": [
+    "vscode",
+    "there-and-back-again",
+    "literate-programmiing"
+  ],
+  "author": "jedcn",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jedcn/vscode-settings/issues"
+  },
+  "homepage": "https://github.com/jedcn/vscode-settings#readme",
+  "dependencies": {
+    "there-and-back-again": "^0.2.0"
+  },
+  "scripts": {
+    "update-markdown-from-config": "echo update",
+    "extract-config-from-markdown": "./node_modules/there-and-back-again/bin/extract-config-from-markdown --config-file ./keybindings.json --markdown-file ./keybindings.json.md && ./node_modules/there-and-back-again/bin/extract-config-from-markdown --config-file ./settings.json --markdown-file ./settings.json.md && ./node_modules/there-and-back-again/bin/extract-config-from-markdown --config-file ./snippets/javascript.json --markdown-file ./snippets/javascript.json.md",
+    "update-markdown-from-config": "./node_modules/there-and-back-again/bin/update-markdown-from-config --config-file ./keybindings.json --markdown-file ./keybindings.json.md && ./node_modules/there-and-back-again/bin/update-markdown-from-config --config-file ./settings.json --markdown-file ./settings.json.md && ./node_modules/there-and-back-again/bin/update-markdown-from-config --config-file ./snippets/javascript.json --markdown-file ./snippets/javascript.json.md"
+  }
+}

--- a/settings.json
+++ b/settings.json
@@ -8,6 +8,9 @@
   "window.zoomLevel": 1,
   // Whitespace
   "files.insertFinalNewline": true,
-  "files.trimTrailingWhitespace": true
+  "files.trimTrailingWhitespace": true,
+  // Indents
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false
 // There's nothing left to see..
 }

--- a/settings.json.md
+++ b/settings.json.md
@@ -41,7 +41,20 @@ You should always trim trailing whitespace.
 
 ```
   "files.insertFinalNewline": true,
-  "files.trimTrailingWhitespace": true
+  "files.trimTrailingWhitespace": true,
+```
+
+## Indents
+
+Visual Code is supposed to automatically detect indents, but it seemed to be
+having trouble in several JS and JSON files I had.
+
+And so-- I explicitly set `editor.tabSize` to `2`. However, this didn't seem to
+take effect until I set `editor.detectIndentation` to `false`.
+
+```
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false
 ```
 
 # There's nothing left to see..


### PR DESCRIPTION
# Overview

This change makes it so that you can run:

* `npm run update-markdown-from-config`
* `npm run extract-config-from-markdown`

And `there-and-back-again` will run it's associated `update-markdown-from-config` or `extract-config-from-markdown` and sync the contents of the config + markdown files.

## General Idea

I'll update the README w/ this shortly-- but the general idea is that if you are in `vscode` and change a config file, then you can run `npm run update-markdown-from-config` and this will move your config change over to the markdown file.

Next, you can go into the markdown file, add a proper heading and code block (containing your new config change), and document the code block.

Lastly, you can run `npm run extract-config-from-markdown` and it will take the config from the code block (which should be identical to what's in the config) and extract it out to the config. In most cases this will just add a new comment in the config-- however-- if you ever decide to modify the contents of a code block this config change would be moved from markdown to config w/ this process.